### PR TITLE
Make htslib update the submodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 
  RUN git clone https://github.com/samtools/htslib.git
  RUN cd htslib && \
-	 git submodule update --init --recursive && \
+     git submodule update --init --recursive && \
      autoheader && \
      autoconf && \
      ./configure --prefix=/usr/local/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@
 
  RUN git clone https://github.com/samtools/htslib.git
  RUN cd htslib && \
+	 git submodule update --init --recursive && \
      autoheader && \
      autoconf && \
      ./configure --prefix=/usr/local/ && \


### PR DESCRIPTION
The htslib git repo requires submodules. This PR quick fixes this problem for the dockerfile.